### PR TITLE
Fix streaming: tool status updates + rAF throttle

### DIFF
--- a/src-tauri/src/agent/manager.rs
+++ b/src-tauri/src/agent/manager.rs
@@ -228,10 +228,37 @@ impl AgentManager {
                                     };
                                     tool_outputs.insert(
                                         tool_use_id.clone(),
-                                        (output_str, *is_error),
+                                        (output_str.clone(), *is_error),
                                     );
+
+                                    // Update current_tool_calls in-place so
+                                    // the frontend sees tool completion immediately.
+                                    for tc in current_tool_calls.iter_mut() {
+                                        if tc.tool_use_id.as_deref() == Some(tool_use_id) {
+                                            tc.output = output_str.clone();
+                                            tc.status = if *is_error {
+                                                "error".to_string()
+                                            } else {
+                                                "done".to_string()
+                                            };
+                                        }
+                                    }
                                 }
                             }
+                        }
+
+                        // Emit updated tool call statuses to the frontend.
+                        if let Some(ref msg_id) = current_message_id {
+                            let _ = handle.emit(
+                                "agent:message",
+                                AgentMessageEvent {
+                                    session_id: sid.clone(),
+                                    message_id: msg_id.clone(),
+                                    role: "assistant".to_string(),
+                                    content: current_content.clone(),
+                                    tool_calls: current_tool_calls.clone(),
+                                },
+                            );
                         }
                     }
 
@@ -253,10 +280,22 @@ impl AgentManager {
                             (output_str.clone(), is_error),
                         );
 
-                        // The next "assistant" snapshot will include the
-                        // tool_use block again, and we'll pick up the stored
-                        // output from tool_outputs at that point. But to give
-                        // the frontend immediate feedback, emit an update now.
+                        // Update current_tool_calls in-place so the emitted
+                        // event reflects the completed status immediately,
+                        // rather than waiting for the next assistant snapshot.
+                        for tc in current_tool_calls.iter_mut() {
+                            if tc.tool_use_id.as_deref() == Some(&tool_use_id) {
+                                tc.output = output_str.clone();
+                                tc.status = if is_error {
+                                    "error".to_string()
+                                } else {
+                                    "done".to_string()
+                                };
+                            }
+                        }
+
+                        // Emit updated state so the frontend shows the tool
+                        // result immediately.
                         if let Some(ref msg_id) = current_message_id {
                             let _ = handle.emit(
                                 "agent:message",

--- a/src/hooks/useAgent.ts
+++ b/src/hooks/useAgent.ts
@@ -1,16 +1,16 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useCallback } from "react";
 import { events } from "../lib/tauri";
 import { useSessionStore } from "../stores/session";
+import type { Message } from "../stores/session";
 
 /**
  * Subscribes to Tauri events for a given session and upserts messages
- * into the Zustand store. Handles React StrictMode double-mounts and
- * async listener setup with a disposed flag to prevent stale handlers.
+ * into the Zustand store. Uses requestAnimationFrame to batch rapid
+ * streaming updates (cumulative snapshots arrive many times per second)
+ * so the frontend renders at most once per frame (~60fps).
  */
 export function useAgent(sessionId: string | null) {
   // Grab stable action references from the store.
-  // Zustand v5 create() returns stable function references, so these
-  // will not change between renders and won't cause effect re-runs.
   const upsertMessage = useSessionStore((s) => s.upsertMessage);
   const updateSessionStatus = useSessionStore((s) => s.updateSessionStatus);
   const updateSessionCost = useSessionStore((s) => s.updateSessionCost);
@@ -21,6 +21,31 @@ export function useAgent(sessionId: string | null) {
   // latest value without needing to re-subscribe.
   const sessionIdRef = useRef(sessionId);
   sessionIdRef.current = sessionId;
+
+  // --- rAF-based throttle for streaming message updates ---
+  // Buffer the latest payload per message_id. Since each assistant event
+  // is a cumulative snapshot, only the latest one for a given id matters.
+  const pendingMessages = useRef<Map<string, Message>>(new Map());
+  const rafId = useRef<number>(0);
+
+  const flushMessages = useCallback(() => {
+    const pending = pendingMessages.current;
+    for (const [, msg] of pending) {
+      upsertMessage(msg.session_id, msg);
+    }
+    pending.clear();
+    rafId.current = 0;
+  }, [upsertMessage]);
+
+  const scheduleMessageUpdate = useCallback(
+    (msg: Message) => {
+      pendingMessages.current.set(msg.id, msg);
+      if (!rafId.current) {
+        rafId.current = requestAnimationFrame(flushMessages);
+      }
+    },
+    [flushMessages]
+  );
 
   useEffect(() => {
     if (!sessionId) return;
@@ -34,7 +59,7 @@ export function useAgent(sessionId: string | null) {
         if (disposed) return;
         if (payload.session_id !== sessionIdRef.current) return;
 
-        upsertMessage(payload.session_id, {
+        scheduleMessageUpdate({
           id: payload.message_id,
           session_id: payload.session_id,
           role: payload.role as "user" | "assistant",
@@ -71,6 +96,17 @@ export function useAgent(sessionId: string | null) {
       const unlistenComplete = await events.onAgentComplete((payload) => {
         if (disposed) return;
         if (payload.session_id !== sessionIdRef.current) return;
+
+        // Flush any pending message updates before marking complete,
+        // so the final content is visible.
+        if (pendingMessages.current.size > 0) {
+          if (rafId.current) {
+            cancelAnimationFrame(rafId.current);
+            rafId.current = 0;
+          }
+          flushMessages();
+        }
+
         updateSessionStatus(payload.session_id, "idle");
         updateSessionCost(payload.session_id, payload.cost_usd, 0);
         // Store duration on the last assistant message for the footer
@@ -97,6 +133,15 @@ export function useAgent(sessionId: string | null) {
 
     return () => {
       disposed = true;
+      // Cancel any pending rAF and flush remaining messages
+      if (rafId.current) {
+        cancelAnimationFrame(rafId.current);
+        rafId.current = 0;
+      }
+      // Flush any remaining buffered messages so nothing is lost
+      if (pendingMessages.current.size > 0) {
+        flushMessages();
+      }
       // Unlisten any listeners that have been set up so far
       for (const unlisten of unlistenFns) {
         unlisten();
@@ -104,7 +149,8 @@ export function useAgent(sessionId: string | null) {
     };
   }, [
     sessionId,
-    upsertMessage,
+    scheduleMessageUpdate,
+    flushMessages,
     updateSessionStatus,
     updateSessionCost,
     updateSessionClaudeId,


### PR DESCRIPTION
## Summary
- **Fix tool call status stuck on "running"**: Both `ToolResult` and `User` event handlers in the Rust backend now update `current_tool_calls` in-place before emitting to the frontend, so tool spinners immediately flip to done/error checkmarks instead of staying stuck
- **Fix User events not emitting updates**: The `User` event handler (which receives tool results) was silently storing results without notifying the frontend — now emits `agent:message` immediately
- **Smooth streaming with rAF throttle**: Frontend message updates are now buffered per message_id and flushed once per animation frame (~60fps), preventing React from being overwhelmed by rapid cumulative snapshots during streaming

## Test plan
- [ ] Start a chat session and observe tool calls (Read, Edit, etc.) — spinners should flip to checkmarks as soon as the tool completes
- [ ] Watch text streaming — should appear smoothly in chunks without visual stuttering
- [ ] Verify final message content is complete after agent finishes (rAF flush on `agent:complete`)
- [ ] Multi-turn conversations: tool calls in earlier messages should retain their done/error status

🤖 Generated with [Claude Code](https://claude.com/claude-code)