### PR TITLE
Fix DMG build: add --bundles dmg flag

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -47,9 +47,13 @@ jobs:
         run: npm ci
 
       - name: Build Tauri app
-        run: npx tauri build --target ${{ matrix.target }}
+        run: npx tauri build --target ${{ matrix.target }} --bundles dmg
         env:
           TAURI_SIGNING_PRIVATE_KEY: ''
+          CI: true
+
+      - name: List build output
+        run: find src-tauri/target/${{ matrix.target }}/release/bundle -type f 2>/dev/null || echo "No bundle directory found"
 
       - name: Upload DMG artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- Adds `--bundles dmg` to `tauri build` so it generates the DMG installer
- Adds a debug step to list build output for troubleshooting

Previous run compiled the Rust binary but skipped bundling — no DMG was produced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)