### PR TITLE
Add Apple Silicon & Intel download links to GitHub Pages

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -215,6 +215,15 @@
       transform: translateY(-1px);
     }
 
+    /* ─── DOWNLOAD LINKS ─── */
+    .download-links {
+      display: flex;
+      gap: 10px;
+      flex-wrap: wrap;
+    }
+
+    .download-links .btn { font-size: 13px; }
+
     /* ─── HERO ─── */
     .hero {
       padding: 160px 0 80px;
@@ -846,10 +855,16 @@
         Always open-source. Always free.
       </p>
       <div class="hero-actions reveal reveal-d3">
-        <a href="https://github.com/samagra14/openforge/releases/latest/download/OpenForge_0.1.0_aarch64.dmg" class="btn btn-accent">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
-          Download for macOS
-        </a>
+        <div class="download-links">
+          <a id="dl-hero-arm" href="https://github.com/samagra14/openforge/releases/latest" class="btn btn-accent">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+            Apple Silicon
+          </a>
+          <a id="dl-hero-intel" href="https://github.com/samagra14/openforge/releases/latest" class="btn btn-accent">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+            Intel Mac
+          </a>
+        </div>
         <a href="https://github.com/samagra14/openforge" target="_blank" rel="noopener" class="btn btn-secondary">
           <svg viewBox="0 0 16 16" width="15" height="15" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"></path></svg>
           View on GitHub
@@ -1067,10 +1082,16 @@
         Download the .dmg, open it, point it at a repo, and let Claude start writing code in its own worktree.
       </p>
       <div class="cta-actions reveal reveal-d3">
-        <a href="https://github.com/samagra14/openforge/releases/latest/download/OpenForge_0.1.0_aarch64.dmg" class="btn btn-accent" style="padding: 12px 24px; font-size: 14px;">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
-          Download .dmg for macOS
-        </a>
+        <div class="download-links">
+          <a id="dl-cta-arm" href="https://github.com/samagra14/openforge/releases/latest" class="btn btn-accent" style="padding: 12px 24px; font-size: 14px;">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+            Apple Silicon (.dmg)
+          </a>
+          <a id="dl-cta-intel" href="https://github.com/samagra14/openforge/releases/latest" class="btn btn-accent" style="padding: 12px 24px; font-size: 14px;">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+            Intel Mac (.dmg)
+          </a>
+        </div>
         <a href="https://github.com/samagra14/openforge" target="_blank" rel="noopener" class="btn btn-secondary" style="padding: 12px 24px; font-size: 14px;">
           Build from source
         </a>
@@ -1099,6 +1120,40 @@
       entries.forEach(e => { if (e.isIntersecting) e.target.classList.add('visible'); });
     }, { threshold: 0.08, rootMargin: '0px 0px -30px 0px' });
     document.querySelectorAll('.reveal').forEach(el => obs.observe(el));
+
+    // Fetch latest release and update download links
+    (function() {
+      var REPO = 'samagra14/openforge';
+      var RELEASES_URL = 'https://github.com/' + REPO + '/releases/latest';
+
+      fetch('https://api.github.com/repos/' + REPO + '/releases/latest')
+        .then(function(r) { return r.json(); })
+        .then(function(release) {
+          if (!release || !release.assets) return;
+
+          var armAsset = null;
+          var intelAsset = null;
+
+          release.assets.forEach(function(a) {
+            if (a.name.match(/aarch64.*\.dmg$/i)) armAsset = a;
+            else if (a.name.match(/x86_64.*\.dmg$/i)) intelAsset = a;
+          });
+
+          var armUrl = armAsset ? armAsset.browser_download_url : RELEASES_URL;
+          var intelUrl = intelAsset ? intelAsset.browser_download_url : RELEASES_URL;
+
+          ['dl-hero-arm', 'dl-cta-arm'].forEach(function(id) {
+            var el = document.getElementById(id);
+            if (el) el.href = armUrl;
+          });
+
+          ['dl-hero-intel', 'dl-cta-intel'].forEach(function(id) {
+            var el = document.getElementById(id);
+            if (el) el.href = intelUrl;
+          });
+        })
+        .catch(function() { /* links already fall back to releases page */ });
+    })();
   </script>
 
 </body>


### PR DESCRIPTION
## Summary
- Replace single hardcoded v0.1.0 download button with separate **Apple Silicon** and **Intel Mac** download buttons in both the hero and CTA sections
- Add JavaScript that fetches the latest release from the GitHub Releases API to dynamically resolve correct DMG download URLs — no more stale version-pinned links
- Graceful fallback: if the API call fails, buttons link to the releases page

## Test plan
- [ ] Open the GitHub Pages site and verify two download buttons appear in the hero section
- [ ] Verify two download buttons appear in the bottom CTA section
- [ ] Inspect the links — they should point to the correct `aarch64` and `x86_64` DMG assets from the latest release
- [ ] Test with network throttling / blocked API — buttons should fall back to the releases page

🤖 Generated with [Claude Code](https://claude.com/claude-code)